### PR TITLE
+ support for local media assets

### DIFF
--- a/Contents/Code/__init__.py
+++ b/Contents/Code/__init__.py
@@ -585,7 +585,7 @@ def Update(metadata, media, lang, force, movie):
 
 ### Agent declaration ##################################################################################################################################################
 class EncoraAgent(Agent.Movies):
-  name, primary_provider, fallback_agent, contributes_to, accepts_from, languages = 'Encora', True, ['com.plexapp.agents.xbmcnfo'], None, ['com.plexapp.agents.xbmcnfo'], [Locale.Language.NoLanguage]
+  name, primary_provider, fallback_agent, contributes_to, accepts_from, languages = 'Encora', True, ['com.plexapp.agents.xbmcnfo'], None, ['com.plexapp.agents.xbmcnfo', 'com.plexapp.agents.localmedia'], [Locale.Language.NoLanguage]
   def search (self, results,  media, lang, manual):  Search (results,  media, lang, manual, True)
   def update (self, metadata, media, lang, force ):  Update (metadata, media, lang, force,  True)
 


### PR DESCRIPTION
all this does is add the com.plexapp.agents.localmedia to the accepted agents for the encora agent.

you may need to restart plex ,, but after you just go into the agent settings on plex, enable Local Media Assets and make sure its the top most entry. above encora and XBMC if you have that enabled. then you can follow these naming schemes and you should be able to view extras :)